### PR TITLE
Fixed curvespoints_packed

### DIFF
--- a/main.py
+++ b/main.py
@@ -83,7 +83,7 @@ def main(filename):
     """The main function"""
     with open(filename, "rb") as file:
         plist = p.load(file)
-        dict_with_data = plist['$objects'][8]
+        dict_with_data = plist['$objects'][11]
 
         curvespoints_packed = dict_with_data['curvespoints']
         curvespoints = unpack_struct(curvespoints_packed, "f")


### PR DESCRIPTION
New versions of `.note` moved the `curvespoints` object in a different position from before, it's now at position 11

<img width="928" alt="Screenshot 2022-04-09 at 00 35 07" src="https://user-images.githubusercontent.com/16304728/162542696-88f41ab2-7396-469a-b25a-37ef05dc5fd6.png">

